### PR TITLE
Refactor/week101 : 프리온보딩 프론트엔드 챌린지 1-1주차 과제

### DIFF
--- a/fe/src/components/FormInput.tsx
+++ b/fe/src/components/FormInput.tsx
@@ -8,7 +8,7 @@ interface FormInputProps {
   placeholder?: string;
   className: string;
   isValid?: boolean;
-  checkValidation?: (target: string, validationResult: boolean) => void;
+  checkValidation: (target: string, validationResult: boolean) => void;
   regexRule?: RegExp;
 }
 
@@ -35,10 +35,12 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
       isFrontBiggerThanRear(inputValueCount.current, 0) && !isValid;
 
     function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-      const regexResult = (regexRule as RegExp).test(event.currentTarget.value);
-      const numberOfValidInputs = event.currentTarget.value.length;
-      inputValueCount.current += numberOfValidInputs;
-      checkValidation && checkValidation(name, regexResult);
+      if (regexRule && regexRule instanceof RegExp) {
+        const regexResult = regexRule.test(event.currentTarget.value);
+        const numberOfValidInputs = event.currentTarget.value.length;
+        inputValueCount.current += numberOfValidInputs;
+        checkValidation(name, regexResult);
+      }
     }
 
     return (

--- a/fe/src/controllers/index.ts
+++ b/fe/src/controllers/index.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { extractInputValue } from 'utils/helpers';
 import loginController from './loginController';
 import signUpController from './signUpController';
 import {
@@ -8,17 +9,15 @@ import {
   deleteTodo,
 } from './todoControllers';
 
-export async function handleLogin(event: React.FormEvent) {
+export async function handleLogin(event: React.FormEvent<HTMLFormElement>) {
   event.preventDefault();
   let result = false;
-  const formEventTarget = event.target as HTMLFormElement;
-  const emailInput = formEventTarget[0] as HTMLInputElement;
-  const passwordInput = formEventTarget[1] as HTMLInputElement;
+  const [emailInputValue, passwordInputValue] = extractInputValue(event);
 
   try {
     const loginResult = await loginController(
-      emailInput.value,
-      passwordInput.value,
+      emailInputValue,
+      passwordInputValue,
     );
     localStorage.setItem('auth', loginResult.token);
     result = true;
@@ -29,17 +28,15 @@ export async function handleLogin(event: React.FormEvent) {
   return result;
 }
 
-export async function handleSignUp(event: React.FormEvent) {
+export async function handleSignUp(event: React.FormEvent<HTMLFormElement>) {
   event.preventDefault();
   let result = false;
-  const formEventTarget = event.target as HTMLFormElement;
-  const emailInput = formEventTarget[0] as HTMLInputElement;
-  const passwordInput = formEventTarget[1] as HTMLInputElement;
+  const [emailInputValue, passwordInputValue] = extractInputValue(event);
 
   try {
     const signUpResult = await signUpController(
-      emailInput.value,
-      passwordInput.value,
+      emailInputValue,
+      passwordInputValue,
     );
     localStorage.setItem('auth', signUpResult.token);
     result = true;
@@ -54,12 +51,16 @@ export async function getTodoLists(
   authenticationToken: string | null,
   todoId = '',
 ) {
+  let result;
+
   try {
     const response = await getTodos(authenticationToken, todoId);
-    return response.data;
+    result = response.data;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 }
 
 export async function createTodoItem(
@@ -72,7 +73,7 @@ export async function createTodoItem(
     const response = await createTodo(authenticationToken, content);
     result = true;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
 
   return result;
@@ -89,7 +90,7 @@ export async function updateTodoItem(
     const response = await updateTodo(authenticationToken, todoId, content);
     result = true;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
 
   return result;
@@ -105,7 +106,7 @@ export async function deleteTodoItem(
     const response = await deleteTodo(authenticationToken, todoId);
     result = true;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
 
   return result;

--- a/fe/src/controllers/index.ts
+++ b/fe/src/controllers/index.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TokenType } from 'types';
 import { extractInputValue } from 'utils/helpers';
 import loginController from './loginController';
 import signUpController from './signUpController';
@@ -48,7 +49,7 @@ export async function handleSignUp(event: React.FormEvent<HTMLFormElement>) {
 }
 
 export async function getTodoLists(
-  authenticationToken: string | null,
+  authenticationToken: TokenType,
   todoId = '',
 ) {
   let result;
@@ -64,7 +65,7 @@ export async function getTodoLists(
 }
 
 export async function createTodoItem(
-  authenticationToken: string | null,
+  authenticationToken: TokenType,
   content: string,
 ) {
   let result = false;
@@ -80,7 +81,7 @@ export async function createTodoItem(
 }
 
 export async function updateTodoItem(
-  authenticationToken: string | null,
+  authenticationToken: TokenType,
   todoId: string,
   content: string,
 ) {
@@ -97,7 +98,7 @@ export async function updateTodoItem(
 }
 
 export async function deleteTodoItem(
-  authenticationToken: string | null,
+  authenticationToken: TokenType,
   todoId: string,
 ) {
   let result = false;

--- a/fe/src/controllers/loginController.ts
+++ b/fe/src/controllers/loginController.ts
@@ -2,16 +2,19 @@ import returnApis from 'api/returnApis';
 
 const loginController = async (emailValue: string, passwordValue: string) => {
   const { postData } = returnApis();
+  let result;
 
   try {
     const response = await postData<string, string>(
       '/users/login',
       `email=${emailValue}&password=${passwordValue}`,
     );
-    return response.data;
+    result = response.data;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };
 
 export default loginController;

--- a/fe/src/controllers/signUpController.ts
+++ b/fe/src/controllers/signUpController.ts
@@ -2,16 +2,19 @@ import returnApis from 'api/returnApis';
 
 const signUpController = async (emailValue: string, passwordValue: string) => {
   const { postData } = returnApis();
+  let result;
 
   try {
     const response = await postData<string, string>(
       '/users/create',
       `email=${emailValue}&password=${passwordValue}`,
     );
-    return response.data;
+    result = response.data;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };
 
 export default signUpController;

--- a/fe/src/controllers/todoControllers.ts
+++ b/fe/src/controllers/todoControllers.ts
@@ -6,26 +6,33 @@ const { getData, postData, putData, deleteData } = returnApis();
 
 export const getTodos = async (token: TokenType, todoId = '') => {
   const queryString = todoId && `/${todoId}`;
+  let result;
 
   try {
     const response = await getData(`/todos${queryString}`, {
       headers: { Authorization: token },
     });
-    return response.data;
+    result = response.data;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };
 
 export const createTodo = async (token: TokenType, todoItemContent: string) => {
+  let result;
+
   try {
     const response = await postData('/todos', todoItemContent, {
       headers: { Authorization: token },
     });
-    return response;
+    result = response;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };
 
 export const updateTodo = async (
@@ -33,27 +40,35 @@ export const updateTodo = async (
   todoId: string,
   todoItemContent: string,
 ) => {
+  let result;
+
   try {
     const response = await putData(`/todos/${todoId}`, todoItemContent, {
       headers: {
         Authorization: token,
       },
     });
-    return response;
+    result = response;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };
 
 export const deleteTodo = async (token: TokenType, todoId: string) => {
+  let result;
+
   try {
     const response = await deleteData(`/todos/${todoId}`, {
       headers: {
         Authorization: token,
       },
     });
-    return response;
+    result = response;
   } catch (error) {
-    throw new Error(error as string);
+    if (error instanceof Error) throw new Error(error.message);
   }
+
+  return result;
 };

--- a/fe/src/controllers/todoControllers.ts
+++ b/fe/src/controllers/todoControllers.ts
@@ -1,6 +1,5 @@
 import returnApis from 'api/returnApis';
-
-type TokenType = string | null;
+import { TokenType } from 'types';
 
 const { getData, postData, putData, deleteData } = returnApis();
 

--- a/fe/src/hooks/useCheckLogin.ts
+++ b/fe/src/hooks/useCheckLogin.ts
@@ -1,7 +1,8 @@
 import React from 'react';
+import { TokenType } from 'types';
 
 const useCheckLogin = () => {
-  const [authenticationToken] = React.useState<string | null>(
+  const [authenticationToken] = React.useState<TokenType>(
     localStorage.getItem('auth'),
   );
 

--- a/fe/src/hooks/useValidation.ts
+++ b/fe/src/hooks/useValidation.ts
@@ -1,0 +1,59 @@
+import React from 'react';
+import { isEqual } from 'utils/capsuledConditions';
+
+interface StateInterface {
+  email: boolean;
+  password: boolean;
+  passwordCheck: boolean;
+}
+
+interface ActionInterface {
+  type: string;
+  payload: boolean;
+}
+
+const reducer = (state: StateInterface, action: ActionInterface) => {
+  switch (action.type) {
+    case 'EMAIL':
+      return {
+        ...state,
+        email: action.payload,
+      };
+    case 'PASSWORD':
+      return {
+        ...state,
+        password: action.payload,
+      };
+    case 'PASSWORDCHECK':
+      return {
+        ...state,
+        passwordCheck: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+const initialState: StateInterface = {
+  email: false,
+  password: false,
+  passwordCheck: false,
+};
+
+const useValidation = (mode = 'login') => {
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const disableCondition = isEqual(mode, 'login')
+    ? !(state.email && state.password)
+    : !(state.email && state.password && state.passwordCheck);
+  const checkValidation = (
+    validateTarget: string,
+    validationResult: boolean,
+  ) => {
+    const upperedTargetString = validateTarget.toUpperCase();
+    dispatch({ type: upperedTargetString, payload: validationResult });
+  };
+
+  return { state, disableCondition, checkValidation };
+};
+
+export default useValidation;

--- a/fe/src/index.tsx
+++ b/fe/src/index.tsx
@@ -3,9 +3,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
-);
+const rootElement = document.querySelector('#root');
+if (!rootElement) throw new Error('There are no #root');
+
+const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <App />

--- a/fe/src/pages/Login/index.tsx
+++ b/fe/src/pages/Login/index.tsx
@@ -1,31 +1,19 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { InputValidState } from 'types';
 import { EMAIL_RULE, PASSWORD_RULE } from 'utils/constants';
 import Path from 'routes/Path';
 import useCheckLogin from 'hooks/useCheckLogin';
+import useValidation from 'hooks/useValidation';
 import FormInput from 'components/FormInput';
 import FormSubmitButton from 'components/FormSubmitButton';
 import { handleLogin } from '../../controllers';
 
 function Login() {
-  const [inputValidState, setInputValidState] = React.useState<InputValidState>(
-    {
-      email: false,
-      password: false,
-    },
-  );
-
   const navigate = useNavigate();
 
   const { authenticationToken } = useCheckLogin();
 
-  const checkValidation = (target: string, validationResult: boolean) => {
-    setInputValidState((previousState: InputValidState) => ({
-      ...previousState,
-      [target]: validationResult,
-    }));
-  };
+  const { state, disableCondition, checkValidation } = useValidation();
 
   async function handleSubmit(event: React.FormEvent) {
     const loginResult = await handleLogin(event);
@@ -50,7 +38,7 @@ function Login() {
           text="이메일"
           placeholder="ex) abcd@email.com"
           className="login-input-area"
-          isValid={inputValidState.email}
+          isValid={state.email}
           regexRule={EMAIL_RULE}
           checkValidation={checkValidation}
         />
@@ -60,15 +48,13 @@ function Login() {
           text="비밀번호"
           placeholder="8자리 이상"
           className="login-input-area"
-          isValid={inputValidState.password}
+          isValid={state.password}
           regexRule={PASSWORD_RULE}
           checkValidation={checkValidation}
         />
         <div className="flex-center flex-col w-full py-5">
           <FormSubmitButton
-            disableCondition={
-              !(inputValidState.email && inputValidState.password)
-            }
+            disableCondition={disableCondition}
             additionalStyles="mb-3"
             value="로그인"
           />

--- a/fe/src/pages/Login/index.tsx
+++ b/fe/src/pages/Login/index.tsx
@@ -15,7 +15,7 @@ function Login() {
 
   const { state, disableCondition, checkValidation } = useValidation();
 
-  async function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     const loginResult = await handleLogin(event);
     if (loginResult) {
       alert('로그인 되었습니다.');

--- a/fe/src/pages/SignUp/index.tsx
+++ b/fe/src/pages/SignUp/index.tsx
@@ -1,34 +1,18 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { InputValidState } from 'types';
 import { EMAIL_RULE, PASSWORD_RULE } from 'utils/constants';
 import Path from 'routes/Path';
 import { handleSignUp } from 'controllers/index';
+import useValidation from 'hooks/useValidation';
 import FormInput from 'components/FormInput';
 import FormSubmitButton from 'components/FormSubmitButton';
 
-interface SignUpValidState extends InputValidState {
-  passwordCheck: boolean;
-}
-
 function SignUp() {
-  const [inputValidState, setInputValidState] =
-    React.useState<SignUpValidState>({
-      email: false,
-      password: false,
-      passwordCheck: false,
-    });
-
   const passwordInput = React.useRef<HTMLInputElement | null>(null);
 
   const navigate = useNavigate();
 
-  const checkValidation = (target: string, validationResult: boolean) => {
-    setInputValidState((previousState: SignUpValidState) => ({
-      ...previousState,
-      [target]: validationResult,
-    }));
-  };
+  const { state, disableCondition, checkValidation } = useValidation('signup');
 
   async function handleSubmit(event: React.FormEvent) {
     const signUpResult = await handleSignUp(event);
@@ -53,7 +37,7 @@ function SignUp() {
           text="이메일"
           placeholder="ex) abcd@email.com"
           className="login-input-area"
-          isValid={inputValidState.email}
+          isValid={state.email}
           regexRule={EMAIL_RULE}
           checkValidation={checkValidation}
         />
@@ -64,7 +48,7 @@ function SignUp() {
           text="비밀번호"
           placeholder="비밀번호는 8자리 이상이어야 합니다."
           className="login-input-area"
-          isValid={inputValidState.password}
+          isValid={state.password}
           regexRule={PASSWORD_RULE}
           checkValidation={checkValidation}
         />
@@ -74,7 +58,7 @@ function SignUp() {
           text="비밀번호 확인"
           placeholder="비밀번호를 한 번 더 입력해주세요."
           className="login-input-area"
-          isValid={inputValidState.passwordCheck}
+          isValid={state.passwordCheck}
           // eslint-disable-next-line prefer-regex-literals
           regexRule={
             passwordInput.current
@@ -92,13 +76,7 @@ function SignUp() {
             취소
           </button>
           <FormSubmitButton
-            disableCondition={
-              !(
-                inputValidState.email &&
-                inputValidState.password &&
-                inputValidState.passwordCheck
-              )
-            }
+            disableCondition={disableCondition}
             value="회원가입"
             additionalStyles="w-1/3"
           />

--- a/fe/src/pages/SignUp/index.tsx
+++ b/fe/src/pages/SignUp/index.tsx
@@ -14,7 +14,7 @@ function SignUp() {
 
   const { state, disableCondition, checkValidation } = useValidation('signup');
 
-  async function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     const signUpResult = await handleSignUp(event);
     if (signUpResult) {
       alert('회원가입이 완료되었습니다.');

--- a/fe/src/pages/Todo/components/ItemAddContainer.tsx
+++ b/fe/src/pages/Todo/components/ItemAddContainer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createTodoItem } from 'controllers';
 import useCheckLogin from 'hooks/useCheckLogin';
+import { returnQueryString } from 'utils/helpers';
 import Path from 'routes/Path';
 
 function ItemAddContainer() {
@@ -10,10 +11,7 @@ function ItemAddContainer() {
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
-    const currentForm = event.currentTarget as HTMLFormElement;
-    const titleInput = (currentForm[0] as HTMLInputElement).value;
-    const contentInput = (currentForm[1] as HTMLTextAreaElement).value;
-    const queryString = `title=${titleInput}&content=${contentInput}`;
+    const queryString = returnQueryString(event);
     const createResult = await createTodoItem(authenticationToken, queryString);
 
     if (createResult) {

--- a/fe/src/pages/Todo/components/ItemAddContainer.tsx
+++ b/fe/src/pages/Todo/components/ItemAddContainer.tsx
@@ -9,7 +9,7 @@ function ItemAddContainer() {
   const navigate = useNavigate();
   const { authenticationToken } = useCheckLogin();
 
-  async function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const queryString = returnQueryString(event);
     const createResult = await createTodoItem(authenticationToken, queryString);

--- a/fe/src/pages/Todo/components/ItemModifyContainer.tsx
+++ b/fe/src/pages/Todo/components/ItemModifyContainer.tsx
@@ -11,7 +11,7 @@ function ItemModifyContainer() {
 
   const { state } = useLocation();
 
-  const itemInfo: TodoItemType = state as TodoItemType;
+  const itemInfo = state as TodoItemType;
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/fe/src/pages/Todo/components/ItemModifyContainer.tsx
+++ b/fe/src/pages/Todo/components/ItemModifyContainer.tsx
@@ -11,9 +11,9 @@ function ItemModifyContainer() {
 
   const { state } = useLocation();
 
-  const itemInfo = state as TodoItemType;
+  const itemInfo: TodoItemType = state as TodoItemType;
 
-  async function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const queryString = returnQueryString(event);
     const updateResult = await updateTodoItem(

--- a/fe/src/pages/Todo/components/ItemModifyContainer.tsx
+++ b/fe/src/pages/Todo/components/ItemModifyContainer.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { updateTodoItem } from 'controllers';
 import { TodoItemType } from 'types';
 import useCheckLogin from 'hooks/useCheckLogin';
+import { returnQueryString } from 'utils/helpers';
 
 function ItemModifyContainer() {
   const navigate = useNavigate();
@@ -14,10 +15,7 @@ function ItemModifyContainer() {
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
-    const currentForm = event.currentTarget as HTMLFormElement;
-    const titleInput = (currentForm[0] as HTMLInputElement).value;
-    const contentInput = (currentForm[1] as HTMLTextAreaElement).value;
-    const queryString = `title=${titleInput}&content=${contentInput}`;
+    const queryString = returnQueryString(event);
     const updateResult = await updateTodoItem(
       authenticationToken,
       itemInfo.id,

--- a/fe/src/pages/Todo/components/TodoDetail.tsx
+++ b/fe/src/pages/Todo/components/TodoDetail.tsx
@@ -33,16 +33,22 @@ function TodoDetail() {
     });
 
   React.useEffect(() => {
-    getTodoLists(authenticationToken, param.id).then((result) => {
-      setItemInfo((previousInfo: TodoItemType) => ({
-        ...previousInfo,
-        id: result.id,
-        title: result.title,
-        content: result.content,
-        createdAt: result.createdAt,
-        updatedAt: result.updatedAt,
-      }));
-    });
+    const setGetResultToList = async () => {
+      try {
+        const getResult = await getTodoLists(authenticationToken, param.id);
+        setItemInfo((previousInfo: TodoItemType) => ({
+          ...previousInfo,
+          id: getResult.id,
+          title: getResult.title,
+          content: getResult.content,
+          createdAt: getResult.createdAt,
+          updatedAt: getResult.updatedAt,
+        }));
+      } catch (error) {
+        throw new Error(error as string);
+      }
+    };
+    setGetResultToList();
   }, [param, authenticationToken]);
 
   return (

--- a/fe/src/pages/Todo/components/TodoDetail.tsx
+++ b/fe/src/pages/Todo/components/TodoDetail.tsx
@@ -45,7 +45,7 @@ function TodoDetail() {
           updatedAt: getResult.updatedAt,
         }));
       } catch (error) {
-        throw new Error(error as string);
+        if (error instanceof Error) throw new Error(error.message);
       }
     };
     setGetResultToList();

--- a/fe/src/pages/Todo/index.tsx
+++ b/fe/src/pages/Todo/index.tsx
@@ -27,7 +27,7 @@ function Todo() {
         const getResult = await getTodoLists(authenticationToken);
         setTodoList(getResult);
       } catch (error) {
-        throw new Error(error as string);
+        if (error instanceof Error) throw new Error(error.message);
       }
     };
     setGetResultToList();

--- a/fe/src/pages/Todo/index.tsx
+++ b/fe/src/pages/Todo/index.tsx
@@ -22,7 +22,15 @@ function Todo() {
   }, [navigate, authenticationToken]);
 
   React.useEffect(() => {
-    getTodoLists(authenticationToken).then((res) => setTodoList(res));
+    const setGetResultToList = async () => {
+      try {
+        const getResult = await getTodoLists(authenticationToken);
+        setTodoList(getResult);
+      } catch (error) {
+        throw new Error(error as string);
+      }
+    };
+    setGetResultToList();
   }, [location.pathname, authenticationToken]);
 
   if (!authenticationToken) return <div />;

--- a/fe/src/types/index.d.ts
+++ b/fe/src/types/index.d.ts
@@ -1,8 +1,3 @@
-export interface InputValidState {
-  email: boolean;
-  password: boolean;
-}
-
 export interface TodoItemType {
   id: string;
   title: string;
@@ -14,3 +9,5 @@ export interface TodoItemType {
 export interface ButtonProps extends TodoItemType {
   additionalStyle?: string;
 }
+
+export type TokenType = string | null;

--- a/fe/src/utils/helpers.ts
+++ b/fe/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import format from 'date-fns/format';
 
 export const returnAlertMessage = (locationString: string) => {
@@ -20,4 +21,13 @@ export const shortenString = (stringToShorten: string) => {
   return stringToShorten.length <= 5
     ? stringToShorten
     : stringToShorten.slice(0, 5).concat('...');
+};
+
+export const returnQueryString = (event: React.FormEvent) => {
+  const currentForm = event.currentTarget as HTMLFormElement;
+  const titleInput = (currentForm[0] as HTMLInputElement).value;
+  const contentInput = (currentForm[1] as HTMLTextAreaElement).value;
+  const queryString = `title=${titleInput}&content=${contentInput}`;
+
+  return queryString;
 };

--- a/fe/src/utils/helpers.ts
+++ b/fe/src/utils/helpers.ts
@@ -23,10 +23,20 @@ export const shortenString = (stringToShorten: string) => {
     : stringToShorten.slice(0, 5).concat('...');
 };
 
-export const returnQueryString = (event: React.FormEvent) => {
-  const currentForm = event.currentTarget as HTMLFormElement;
-  const titleInput = (currentForm[0] as HTMLInputElement).value;
-  const contentInput = (currentForm[1] as HTMLTextAreaElement).value;
+export const extractInputValue = (event: React.FormEvent<HTMLFormElement>) => {
+  const formEventTarget = event.currentTarget;
+  let firstValue = '';
+  let secondValue = '';
+  const firstInput = formEventTarget['0'];
+  const secondInput = formEventTarget['1'];
+  if (firstInput instanceof HTMLInputElement) firstValue = firstInput.value;
+  if (secondInput instanceof HTMLInputElement) secondValue = secondInput.value;
+
+  return [firstValue, secondValue];
+};
+
+export const returnQueryString = (event: React.FormEvent<HTMLFormElement>) => {
+  const [titleInput, contentInput] = extractInputValue(event);
   const queryString = `title=${titleInput}&content=${contentInput}`;
 
   return queryString;


### PR DESCRIPTION
## 과제 진행사항

### 1. 변수명 수정
- 백엔드 통신 담당 API명 수정: `HttpRequest` -> `communicateServerBy`([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/2ff52bcd84176c7c209a7ff4492c13cd4f1bf907)) -> `returnApis`([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/11613ff4e13c25349dddb754fa86767bef057df3), 이하 동일 커밋 출처)
- 유효성 검사 불합격시 표시하는 문구 식별자: `validationResult` -> `validationFailedString`
- 유효성 검사를 통과한 `input`요소 개수: `event.currentTarget.value.length` -> `numberOfValidInputs`
- 버튼 컴포넌트 이름: `FormSubmit` -> `FormSubmitButton`
- 투두리스트 아이템 내용(제목 + 본문): `todoContent` -> `todoItemContent`
- 투두리스트 아이템 추가/수정 컴포넌트: `Add/ModifyItemDetail` -> `ItemAdd/ModifyContainer`
- 선택된 아이템의 스타일을 정의한 문자열 식별자: `checkedString` -> `checkedStringStyle`
- 투두리스트 아이템 본문 중 \n 문자를 포함하는 본문을 `<p>` 여러 개로 수정한 결과물: `contents` -> `processedContents`

### 2. 라우터 주소 RESTful 작명법에 따라 수정([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/a38fef2e31054ad31a65e032521028ec2a6074ae), [참고자료](https://docs.microsoft.com/ko-kr/azure/architecture/best-practices/api-design))
- 요약
    - `/items`: 투두리스트 기본화면 - 투두리스트 목록 표시
    - `:id`: 투두리스트 아이템 상세 내용 화면 - `/items/아이디` 형태로 표시
    - `:id/modify`: 투두리스트 아이템 내용 수정 화면
    - `/`: 로그인 상태에 따라 `/items` 혹은 `/auth`로 리다이렉션 전용 페이지
    ![image](https://user-images.githubusercontent.com/20578093/184367390-d01bbefe-3686-416d-96d4-9f5689a6d57b.png)

### 3. 클래스는 데이터 + 동작을 같이 관리할 때 사용하므로, 클래스를 함수로 변경([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/2ff52bcd84176c7c209a7ff4492c13cd4f1bf907))
- 커밋 참조

### 4. 뷰, 비즈니스 로직 분리
#### (1) 유효성 검사 로직 분리([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/a51ffeba8c30029c8e2f4921a798c492213a448c))
- 요약
    - 기존: 로그인, 회원가입 컴포넌트 내부에서 유효성 검사까지 수행
    - 수정: useValidation 커스텀 훅을 만들어 유효성 로직을 컴포넌트로부터 분리
    ![image](https://user-images.githubusercontent.com/20578093/184368769-8efcd998-02f9-4f98-8feb-7f78af70fd7f.png)

#### (2) submit 이벤트 핸들러 로직 세분화([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/47255d699f7130d16dad821f8058a9bfc9763a49))
- 요약
    - 기존: submit 이벤트를 사용하는 컴포넌트 내부에서 `event.target(= HTMLFormElement)`의 `input.value`를 추출해 서버 통신용 queryString 생성
    - 수정: 전달된 `React.FormEvent`로부터 `input.value`를 추출해 queryString을 만들어 반환하는 헬퍼 함수 생성
    ![image](https://user-images.githubusercontent.com/20578093/184369194-99bb33be-887d-43f9-86e1-0ba20290d954.png)
    ![image](https://user-images.githubusercontent.com/20578093/184369274-223cf23f-061b-40b0-ada1-4e8ea45003fc.png)

### 5. 타입 단언 전부 타입 가드로 수정([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/a097cf65f130beff10855de4f0254b70e0935043))
- 커밋 참조

### 6. 반복 타입 추상화([커밋](https://github.com/godcl1623/wanted-pre-onboarding-challenge-fe-1/commit/aee135555fce4d361c37617895e47f7c0aafc627))
- 커밋 참조